### PR TITLE
Bug fixes

### DIFF
--- a/balenaapi/balenaapi.go
+++ b/balenaapi/balenaapi.go
@@ -61,7 +61,7 @@ func GetTagValue(apiKey string, uuid string, tagKey string) (string, error) {
 	if len(tags.Data) == 0 {
 		return "", nil
 	} else if len(tags.Data) > 1 {
-		return "", errors.New(fmt.Sprintf("Expected only 1 tag, received %s", len(tags.Data)))
+		return "", errors.New(fmt.Sprintf("Expected only 1 tag, received %d", len(tags.Data)))
 	} else {
 		window := tags.Data[0].Value
 		return window, nil

--- a/balenaapi/balenaapi.go
+++ b/balenaapi/balenaapi.go
@@ -37,7 +37,7 @@ func GetTagValue(apiKey string, uuid string, tagKey string) (string, error) {
 		},
 		RequestTimeout: time.Duration(5) * time.Second,
 	}
-	filters, err := UrlEncoded(fmt.Sprintf("$filter=device/uuid eq '%s'&$filter=tag_key eq '%s'", uuid, tagKey))
+	filters, err := UrlEncoded(fmt.Sprintf("$filter=device/uuid eq '%s' and tag_key eq '%s'", uuid, tagKey))
 	if err != nil {
 		return "", err
 	}
@@ -60,6 +60,8 @@ func GetTagValue(apiKey string, uuid string, tagKey string) (string, error) {
 
 	if len(tags.Data) == 0 {
 		return "", nil
+	} else if len(tags.Data) > 1 {
+		return "", errors.New(fmt.Sprintf("Expected only 1 tag, received %s", len(tags.Data)))
 	} else {
 		window := tags.Data[0].Value
 		return window, nil

--- a/lockfile/lockfile.go
+++ b/lockfile/lockfile.go
@@ -6,33 +6,38 @@ import (
 
 type Lockfile struct {
 	filename string
-	fd       *os.File
 }
 
 func (l *Lockfile) Lock() error {
-	if l.fd == nil {
+	// Check if file exists
+	if _, err := os.Stat(l.filename); err == nil {
+		// Lock is already taken
+		return nil
+	} else if os.IsNotExist(err) {
+		// Take the lock by creating a file.
 		fd, err := os.OpenFile(l.filename, os.O_EXCL|os.O_CREATE, 0444)
 		if err != nil {
 			return err
 		}
-		l.fd = fd
+		// Immediately close the file descriptor
+		if err := fd.Close(); err != nil {
+			return err
+		}
+	} else {
+		// os.IsNotExists may be false in certain conditions even if the file exists,
+		// i.e. no permissions. Return an error in this case.
+		return err
 	}
 	return nil
 }
 
 func (l *Lockfile) Unlock() error {
-	if l.fd != nil {
-		if err := l.fd.Close(); err != nil {
-			return err
-		}
-		if err := os.Remove(l.filename); err != nil {
-			return err
-		}
-		l.fd = nil
+	if err := os.RemoveAll(l.filename); err != nil {
+		return err
 	}
 	return nil
 }
 
 func New(filename string) *Lockfile {
-	return &Lockfile{filename, nil}
+	return &Lockfile{filename}
 }


### PR DESCRIPTION
https://trello.com/c/TQ4TrQtV/763-p1-bug-maintenance-window-tool-doesnt-delete-lockfile-sometimes
https://trello.com/c/ldg9APDd/764-p1-bug-maintenance-window-can-read-windows-from-wrong-devices

- Fix issue where wrong device tags can be returned 
- Change lockfile logic to correctly remove files created by other processes